### PR TITLE
Add BanditTweaks spawn and friendly fire adjustments

### DIFF
--- a/BanditTweaks/media/lua/client/BanditTweaksClient.lua
+++ b/BanditTweaks/media/lua/client/BanditTweaksClient.lua
@@ -1,0 +1,244 @@
+if isServer() then return end
+
+require "ISUI/ISWorldObjectContextMenu"
+require "ISUI/ISUIElement"
+
+local trackedHostiles = {}
+local trackedFriendlyHealth = {}
+
+local function clearFriendlyHealth()
+    for zombie in pairs(trackedFriendlyHealth) do
+        trackedFriendlyHealth[zombie] = nil
+    end
+end
+
+function BanditTweaks.ToggleFriendlyFire()
+    local newState = not BanditTweaks.Config.friendlyFireEnabled
+    BanditTweaks.SetFriendlyFireEnabled(newState)
+
+    if newState then
+        clearFriendlyHealth()
+    end
+
+    local player = getSpecificPlayer(0)
+    if player then
+        local message = newState and "Friendly fire enabled" or "Friendly fire disabled"
+        player:Say(message)
+    end
+end
+
+local function addFriendlyFireOption(playerNum, context, worldobjects, test)
+    local label
+    if BanditTweaks.Config.friendlyFireEnabled then
+        label = "Disable Friendly Fire"
+    else
+        label = "Enable Friendly Fire"
+    end
+
+    local option = context:addOption("[Bandit Tweaks] " .. label, worldobjects, BanditTweaks.ToggleFriendlyFire)
+    if option then
+        local toolTip = ISWorldObjectContextMenu.addToolTip()
+        toolTip.description = "When disabled you cannot damage friendly bandits."
+        toolTip:setName("Enable Friendly Fire")
+        option.toolTip = toolTip
+    end
+end
+Events.OnFillWorldObjectContextMenu.Add(addFriendlyFireOption)
+
+local function shouldTrackFriendly()
+    return not BanditTweaks.Config.friendlyFireEnabled
+end
+
+local function onZombieUpdate(zombie)
+    if not zombie then
+        return
+    end
+    if not zombie:getVariableBoolean("Bandit") then
+        trackedHostiles[zombie] = nil
+        trackedFriendlyHealth[zombie] = nil
+        return
+    end
+
+    local brain = BanditBrain and BanditBrain.Get(zombie)
+    if not brain then
+        trackedHostiles[zombie] = nil
+        trackedFriendlyHealth[zombie] = nil
+        return
+    end
+
+    local isHostile = brain.hostile or brain.hostileP
+    if isHostile then
+        trackedHostiles[zombie] = true
+        trackedFriendlyHealth[zombie] = nil
+    else
+        trackedHostiles[zombie] = nil
+        if shouldTrackFriendly() then
+            trackedFriendlyHealth[zombie] = zombie:getHealth()
+        else
+            trackedFriendlyHealth[zombie] = nil
+        end
+    end
+end
+Events.OnZombieUpdate.Add(onZombieUpdate)
+
+local function onZombieDead(zombie)
+    trackedHostiles[zombie] = nil
+    trackedFriendlyHealth[zombie] = nil
+end
+Events.OnZombieDead.Add(onZombieDead)
+
+local function onHitZombie(zombie, attacker, bodyPartType, handWeapon)
+    if BanditTweaks.Config.friendlyFireEnabled then
+        return
+    end
+
+    if not zombie or not zombie:getVariableBoolean("Bandit") then
+        return
+    end
+
+    local brain = BanditBrain and BanditBrain.Get(zombie)
+    if not brain or brain.hostile or brain.hostileP then
+        return
+    end
+
+    if not attacker or not instanceof(attacker, "IsoPlayer") then
+        return
+    end
+
+    local previous = trackedFriendlyHealth[zombie]
+    if previous then
+        zombie:setHealth(previous)
+    end
+end
+Events.OnHitZombie.Add(onHitZombie)
+
+local function ensureIndicatorPanel()
+    if BanditTweaks.IndicatorPanel then
+        return
+    end
+
+    local width = getCore():getScreenWidth()
+    local height = getCore():getScreenHeight()
+    local panel = ISUIElement:new(0, 0, width, height)
+    panel:initialise()
+    panel:setAnchorRight(true)
+    panel:setAnchorBottom(true)
+    panel:setAlwaysOnTop(true)
+
+    function panel:render()
+        if not isIngameState() then
+            return
+        end
+
+        local player = getSpecificPlayer(0)
+        if not player then
+            return
+        end
+
+        local zoom = getCore():getZoom(player:getPlayerNum())
+        local size = math.max(4, math.floor(10 / zoom))
+        local verticalOffset = 85 / zoom
+
+        for zombie in pairs(trackedHostiles) do
+            if zombie and not zombie:isDead() then
+                local screenX, screenY = ISCoordConversion.ToScreen(zombie:getX(), zombie:getY(), zombie:getZ())
+                local drawX = screenX / zoom - size / 2
+                local drawY = screenY / zoom - verticalOffset - size
+                self:drawRect(drawX, drawY, size, size, 0.85, 1, 0, 0)
+                self:drawRectBorder(drawX, drawY, size, size, 1, 0.35, 0, 0)
+            end
+        end
+    end
+
+    panel:addToUIManager()
+    BanditTweaks.IndicatorPanel = panel
+end
+Events.OnGameStart.Add(ensureIndicatorPanel)
+
+local function updatePanelSize()
+    if not BanditTweaks.IndicatorPanel then
+        return
+    end
+
+    BanditTweaks.IndicatorPanel:setWidth(getCore():getScreenWidth())
+    BanditTweaks.IndicatorPanel:setHeight(getCore():getScreenHeight())
+end
+Events.OnResolutionChange.Add(updatePanelSize)
+
+local function patchFriendlyFireCheck()
+    if BanditTweaks._patchedFriendlyFireCheck then
+        Events.OnTick.Remove(patchFriendlyFireCheck)
+        return
+    end
+
+    if BanditPlayer and BanditPlayer.CheckFriendlyFire then
+        local original = BanditPlayer.CheckFriendlyFire
+        BanditPlayer.CheckFriendlyFire = function(bandit, attacker)
+            if not BanditTweaks.Config.friendlyFireEnabled then
+                return
+            end
+            return original(bandit, attacker)
+        end
+        BanditTweaks._patchedFriendlyFireCheck = true
+        Events.OnTick.Remove(patchFriendlyFireCheck)
+    end
+end
+Events.OnTick.Add(patchFriendlyFireCheck)
+
+local hostilePhaseNames = {"SpawnGang", "SpawnBandits", "SpawnInmates"}
+
+local function tryPatchDayOne()
+    if BanditTweaks._dayOnePatched then
+        Events.OnTick.Remove(tryPatchDayOne)
+        return
+    end
+
+    if not BanditTweaks.IsModActive("BanditsDayOne") then
+        BanditTweaks._dayOnePatched = true
+        Events.OnTick.Remove(tryPatchDayOne)
+        return
+    end
+
+    local patchedSomething = false
+
+    if DOPhases then
+        for _, name in ipairs(hostilePhaseNames) do
+            if not BanditTweaks["_patchedPhase" .. name] and type(DOPhases[name]) == "function" then
+                local original = DOPhases[name]
+                DOPhases[name] = function(player, ...)
+                    if ZombRandFloat(0, 1) > BanditTweaks.Config.hostileEventChance then
+                        return
+                    end
+                    return original(player, ...)
+                end
+                BanditTweaks["_patchedPhase" .. name] = true
+                patchedSomething = true
+            end
+        end
+    end
+
+    if BanditScheduler and BanditScheduler.GenerateSpawnPoint and not BanditTweaks._patchedScheduler then
+        local originalGenerate = BanditScheduler.GenerateSpawnPoint
+        BanditScheduler.GenerateSpawnPoint = function(player, dist, ...)
+            if type(dist) == "number" then
+                dist = BanditTweaks.AdjustBanditSpawnDistance(dist)
+            end
+            return originalGenerate(player, dist, ...)
+        end
+        BanditTweaks._patchedScheduler = true
+        patchedSomething = true
+    end
+
+    local allPatched = BanditTweaks._patchedScheduler
+    for _, name in ipairs(hostilePhaseNames) do
+        allPatched = allPatched and BanditTweaks["_patchedPhase" .. name]
+    end
+
+    if allPatched then
+        BanditTweaks._dayOnePatched = true
+        Events.OnTick.Remove(tryPatchDayOne)
+    elseif not patchedSomething then
+        -- wait for next tick when the functions are available
+    end
+end
+Events.OnTick.Add(tryPatchDayOne)

--- a/BanditTweaks/media/lua/shared/BanditTweaksShared.lua
+++ b/BanditTweaks/media/lua/shared/BanditTweaksShared.lua
@@ -1,0 +1,145 @@
+BanditTweaks = BanditTweaks or {}
+BanditTweaks.Config = BanditTweaks.Config or {}
+
+BanditTweaks.Config.spawnDistanceMultiplier = 1.5
+BanditTweaks.Config.hostileSpawnChanceMultiplier = 0.1
+BanditTweaks.Config.hostileEventChance = 0.1
+BanditTweaks.Config.friendlyFireEnabled = BanditTweaks.Config.friendlyFireEnabled ~= false
+
+BanditTweaks._dataKey = "BanditTweaks"
+BanditTweaks._modData = BanditTweaks._modData or nil
+
+function BanditTweaks.IsModActive(modId)
+    local mods = getActivatedMods()
+    if not mods then
+        return false
+    end
+
+    for i = 0, mods:size() - 1 do
+        local activeId = mods:get(i)
+        if activeId then
+            activeId = activeId:gsub("^\\", "")
+            if activeId == modId then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+local function loadModData(isNewGame)
+    local data = ModData.getOrCreate(BanditTweaks._dataKey)
+    if isClient() then
+        ModData.request(BanditTweaks._dataKey)
+    end
+
+    if data.friendlyFireEnabled == nil then
+        data.friendlyFireEnabled = true
+    end
+
+    BanditTweaks._modData = data
+    BanditTweaks.Config.friendlyFireEnabled = data.friendlyFireEnabled ~= false
+end
+Events.OnInitGlobalModData.Add(loadModData)
+
+local function receiveModData(key, data)
+    if key == BanditTweaks._dataKey and data then
+        BanditTweaks._modData = data
+        BanditTweaks.Config.friendlyFireEnabled = data.friendlyFireEnabled ~= false
+    end
+end
+Events.OnReceiveGlobalModData.Add(receiveModData)
+
+function BanditTweaks.SetFriendlyFireEnabled(enabled)
+    enabled = enabled and true or false
+    BanditTweaks.Config.friendlyFireEnabled = enabled
+
+    if BanditTweaks._modData then
+        BanditTweaks._modData.friendlyFireEnabled = enabled
+        if isServer() then
+            ModData.transmit(BanditTweaks._dataKey)
+        end
+    end
+end
+
+function BanditTweaks.AdjustBanditSpawnDistance(dist)
+    if type(dist) == "number" then
+        dist = dist * BanditTweaks.Config.spawnDistanceMultiplier
+    end
+    return dist
+end
+
+function BanditTweaks.AdjustClanSpawnChances()
+    if not BanditCustom or not BanditCustom.clanData then
+        return
+    end
+
+    for _, clan in pairs(BanditCustom.clanData) do
+        local spawn = clan and clan.spawn
+        if spawn and spawn.friendly == false and not spawn._BanditTweaksAdjusted then
+            if type(spawn.spawnChance) == "number" then
+                spawn.spawnChance = spawn.spawnChance * BanditTweaks.Config.hostileSpawnChanceMultiplier
+            end
+            spawn._BanditTweaksAdjusted = true
+        end
+    end
+end
+
+local function tryPatchBanditCustom()
+    if BanditTweaks._patchedBanditCustom then
+        Events.OnTick.Remove(tryPatchBanditCustom)
+        return
+    end
+
+    if BanditCustom and BanditCustom.Load then
+        local originalLoad = BanditCustom.Load
+        BanditCustom.Load = function(...)
+            local result = originalLoad(...)
+            BanditTweaks.AdjustClanSpawnChances()
+            return result
+        end
+        BanditTweaks._patchedBanditCustom = true
+        BanditTweaks.AdjustClanSpawnChances()
+        Events.OnTick.Remove(tryPatchBanditCustom)
+    end
+end
+Events.OnTick.Add(tryPatchBanditCustom)
+
+local function tryPatchSpawnType()
+    if BanditTweaks._patchedSpawnType then
+        Events.OnTick.Remove(tryPatchSpawnType)
+        return
+    end
+
+    if BanditServer and BanditServer.Spawner and BanditServer.Spawner.Type then
+        local index = 1
+        while true do
+            local name, value = debug.getupvalue(BanditServer.Spawner.Type, index)
+            if not name then
+                break
+            end
+            if name == "spawnType" and type(value) == "function" then
+                local original = value
+                local function tweakedSpawnType(player, args)
+                    if args and args.dist then
+                        args.dist = BanditTweaks.AdjustBanditSpawnDistance(args.dist)
+                    end
+                    return original(player, args)
+                end
+                debug.setupvalue(BanditServer.Spawner.Type, index, tweakedSpawnType)
+                BanditTweaks._patchedSpawnType = true
+                break
+            end
+            index = index + 1
+        end
+
+        if BanditTweaks._patchedSpawnType then
+            Events.OnTick.Remove(tryPatchSpawnType)
+        end
+    end
+end
+
+if isServer() then
+    Events.OnTick.Add(tryPatchSpawnType)
+end

--- a/BanditTweaks/mod.info
+++ b/BanditTweaks/mod.info
@@ -2,5 +2,5 @@ name=Bandit Tweaks
 poster=poster.png
 id=BanditTweaks
 description=Tweaks for the Bandit Mod
-require=Bandits2
+require=Bandits2;BanditsDayOne
 url=http://theindiestone.com/forums/index.php/topic/2011-how-to-use-the-upcoming-modloader/


### PR DESCRIPTION
## Summary
- add shared helpers to reduce hostile bandit spawn chance and push spawns further from the player
- introduce client logic for the friendly fire toggle, prevention hooks, and hostile visual indicators
- require both Bandits2 and BanditsDayOne so tweaks load after their content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d28f14700c8332b0e6a227ae20b261