### PR TITLE
Add sandbox options for Bandit Tweaks settings

### DIFF
--- a/BanditTweaks/42/media/lua/shared/BanditTweaksShared.lua
+++ b/BanditTweaks/42/media/lua/shared/BanditTweaksShared.lua
@@ -1,10 +1,46 @@
 BanditTweaks = BanditTweaks or {}
 BanditTweaks.Config = BanditTweaks.Config or {}
+BanditTweaks.Defaults = BanditTweaks.Defaults or {}
 
-BanditTweaks.Config.spawnDistanceMultiplier = 1.5
-BanditTweaks.Config.hostileSpawnChanceMultiplier = 0.1
-BanditTweaks.Config.hostileEventChance = 0.1
+BanditTweaks.Defaults.spawnDistanceMultiplier = 1.5
+BanditTweaks.Defaults.hostileSpawnChanceMultiplier = 0.1
+BanditTweaks.Defaults.hostileEventChance = 0.1
+BanditTweaks.Defaults.friendlyFireEnabled = true
+
+BanditTweaks.Config.spawnDistanceMultiplier = BanditTweaks.Config.spawnDistanceMultiplier or BanditTweaks.Defaults.spawnDistanceMultiplier
+BanditTweaks.Config.hostileSpawnChanceMultiplier = BanditTweaks.Config.hostileSpawnChanceMultiplier or BanditTweaks.Defaults.hostileSpawnChanceMultiplier
+BanditTweaks.Config.hostileEventChance = BanditTweaks.Config.hostileEventChance or BanditTweaks.Defaults.hostileEventChance
 BanditTweaks.Config.friendlyFireEnabled = BanditTweaks.Config.friendlyFireEnabled ~= false
+
+local function getSandboxNumber(options, key, default)
+    local value = options and options[key]
+    if type(value) == "number" then
+        return value
+    end
+    return default
+end
+
+function BanditTweaks.UpdateConfigFromSandbox()
+    local options = SandboxVars and SandboxVars.BanditTweaks
+    BanditTweaks.Config.spawnDistanceMultiplier = getSandboxNumber(options, "SpawnDistanceMultiplier", BanditTweaks.Defaults.spawnDistanceMultiplier)
+    BanditTweaks.Config.hostileSpawnChanceMultiplier = getSandboxNumber(options, "HostileSpawnChanceMultiplier", BanditTweaks.Defaults.hostileSpawnChanceMultiplier)
+    BanditTweaks.Config.hostileEventChance = getSandboxNumber(options, "HostileEventChance", BanditTweaks.Defaults.hostileEventChance)
+end
+
+BanditTweaks.UpdateConfigFromSandbox()
+
+if Events and Events.OnGameStart then
+    Events.OnGameStart.Add(BanditTweaks.UpdateConfigFromSandbox)
+end
+if Events and Events.OnServerStarted then
+    Events.OnServerStarted.Add(BanditTweaks.UpdateConfigFromSandbox)
+end
+if Events and Events.OnSandboxOptionsChanged then
+    Events.OnSandboxOptionsChanged.Add(BanditTweaks.UpdateConfigFromSandbox)
+end
+if Events and Events.OnLoad then
+    Events.OnLoad.Add(BanditTweaks.UpdateConfigFromSandbox)
+end
 
 BanditTweaks._dataKey = "BanditTweaks"
 BanditTweaks._modData = BanditTweaks._modData or nil
@@ -29,13 +65,20 @@ function BanditTweaks.IsModActive(modId)
 end
 
 local function loadModData(isNewGame)
+    BanditTweaks.UpdateConfigFromSandbox()
+
     local data = ModData.getOrCreate(BanditTweaks._dataKey)
     if isClient() then
         ModData.request(BanditTweaks._dataKey)
     end
 
     if data.friendlyFireEnabled == nil then
-        data.friendlyFireEnabled = true
+        local defaultFriendly = BanditTweaks.Defaults.friendlyFireEnabled
+        local options = SandboxVars and SandboxVars.BanditTweaks
+        if options and options.FriendlyFireEnabled ~= nil then
+            defaultFriendly = options.FriendlyFireEnabled and true or false
+        end
+        data.friendlyFireEnabled = defaultFriendly
     end
 
     BanditTweaks._modData = data

--- a/BanditTweaks/42/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/BanditTweaks/42/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -1,0 +1,17 @@
+Sandbox_EN = {
+
+    Sandbox_BanditTweaks = "Bandit Tweaks",
+
+    Sandbox_BanditTweaks.SpawnDistanceMultiplier = "Spawn distance multiplier",
+    Sandbox_BanditTweaks.SpawnDistanceMultiplier_tooltip = "Multiplies the base distance used when spawning bandits.",
+
+    Sandbox_BanditTweaks.HostileSpawnChanceMultiplier = "Hostile clan spawn chance multiplier",
+    Sandbox_BanditTweaks.HostileSpawnChanceMultiplier_tooltip = "Scales the spawn chance applied to hostile bandit clans.",
+
+    Sandbox_BanditTweaks.HostileEventChance = "Hostile bandit event chance",
+    Sandbox_BanditTweaks.HostileEventChance_tooltip = "Chance that scripted hostile bandit events will occur.",
+
+    Sandbox_BanditTweaks.FriendlyFireEnabled = "Friendly fire enabled by default",
+    Sandbox_BanditTweaks.FriendlyFireEnabled_tooltip = "Initial state for friendly fire. Can still be toggled in-game via the context menu.",
+
+}

--- a/BanditTweaks/42/media/sandbox-options.txt
+++ b/BanditTweaks/42/media/sandbox-options.txt
@@ -1,0 +1,21 @@
+VERSION = 1,
+
+option BanditTweaks.SpawnDistanceMultiplier = {
+    type = double, min = 0.25, max = 5, default = 1.50,
+    page = BanditTweaks, translation = BanditTweaks.SpawnDistanceMultiplier, _tooltip = BanditTweaks.SpawnDistanceMultiplier_tooltip,
+}
+
+option BanditTweaks.HostileSpawnChanceMultiplier = {
+    type = double, min = 0.00, max = 2, default = 0.10,
+    page = BanditTweaks, translation = BanditTweaks.HostileSpawnChanceMultiplier, _tooltip = BanditTweaks.HostileSpawnChanceMultiplier_tooltip,
+}
+
+option BanditTweaks.HostileEventChance = {
+    type = double, min = 0.00, max = 1, default = 0.10,
+    page = BanditTweaks, translation = BanditTweaks.HostileEventChance, _tooltip = BanditTweaks.HostileEventChance_tooltip,
+}
+
+option BanditTweaks.FriendlyFireEnabled = {
+    type = boolean, default = true,
+    page = BanditTweaks, translation = BanditTweaks.FriendlyFireEnabled, _tooltip = BanditTweaks.FriendlyFireEnabled_tooltip,
+}

--- a/BanditTweaks/media/lua/shared/BanditTweaksShared.lua
+++ b/BanditTweaks/media/lua/shared/BanditTweaksShared.lua
@@ -1,10 +1,46 @@
 BanditTweaks = BanditTweaks or {}
 BanditTweaks.Config = BanditTweaks.Config or {}
+BanditTweaks.Defaults = BanditTweaks.Defaults or {}
 
-BanditTweaks.Config.spawnDistanceMultiplier = 1.5
-BanditTweaks.Config.hostileSpawnChanceMultiplier = 0.1
-BanditTweaks.Config.hostileEventChance = 0.1
+BanditTweaks.Defaults.spawnDistanceMultiplier = 1.5
+BanditTweaks.Defaults.hostileSpawnChanceMultiplier = 0.1
+BanditTweaks.Defaults.hostileEventChance = 0.1
+BanditTweaks.Defaults.friendlyFireEnabled = true
+
+BanditTweaks.Config.spawnDistanceMultiplier = BanditTweaks.Config.spawnDistanceMultiplier or BanditTweaks.Defaults.spawnDistanceMultiplier
+BanditTweaks.Config.hostileSpawnChanceMultiplier = BanditTweaks.Config.hostileSpawnChanceMultiplier or BanditTweaks.Defaults.hostileSpawnChanceMultiplier
+BanditTweaks.Config.hostileEventChance = BanditTweaks.Config.hostileEventChance or BanditTweaks.Defaults.hostileEventChance
 BanditTweaks.Config.friendlyFireEnabled = BanditTweaks.Config.friendlyFireEnabled ~= false
+
+local function getSandboxNumber(options, key, default)
+    local value = options and options[key]
+    if type(value) == "number" then
+        return value
+    end
+    return default
+end
+
+function BanditTweaks.UpdateConfigFromSandbox()
+    local options = SandboxVars and SandboxVars.BanditTweaks
+    BanditTweaks.Config.spawnDistanceMultiplier = getSandboxNumber(options, "SpawnDistanceMultiplier", BanditTweaks.Defaults.spawnDistanceMultiplier)
+    BanditTweaks.Config.hostileSpawnChanceMultiplier = getSandboxNumber(options, "HostileSpawnChanceMultiplier", BanditTweaks.Defaults.hostileSpawnChanceMultiplier)
+    BanditTweaks.Config.hostileEventChance = getSandboxNumber(options, "HostileEventChance", BanditTweaks.Defaults.hostileEventChance)
+end
+
+BanditTweaks.UpdateConfigFromSandbox()
+
+if Events and Events.OnGameStart then
+    Events.OnGameStart.Add(BanditTweaks.UpdateConfigFromSandbox)
+end
+if Events and Events.OnServerStarted then
+    Events.OnServerStarted.Add(BanditTweaks.UpdateConfigFromSandbox)
+end
+if Events and Events.OnSandboxOptionsChanged then
+    Events.OnSandboxOptionsChanged.Add(BanditTweaks.UpdateConfigFromSandbox)
+end
+if Events and Events.OnLoad then
+    Events.OnLoad.Add(BanditTweaks.UpdateConfigFromSandbox)
+end
 
 BanditTweaks._dataKey = "BanditTweaks"
 BanditTweaks._modData = BanditTweaks._modData or nil
@@ -29,13 +65,20 @@ function BanditTweaks.IsModActive(modId)
 end
 
 local function loadModData(isNewGame)
+    BanditTweaks.UpdateConfigFromSandbox()
+
     local data = ModData.getOrCreate(BanditTweaks._dataKey)
     if isClient() then
         ModData.request(BanditTweaks._dataKey)
     end
 
     if data.friendlyFireEnabled == nil then
-        data.friendlyFireEnabled = true
+        local defaultFriendly = BanditTweaks.Defaults.friendlyFireEnabled
+        local options = SandboxVars and SandboxVars.BanditTweaks
+        if options and options.FriendlyFireEnabled ~= nil then
+            defaultFriendly = options.FriendlyFireEnabled and true or false
+        end
+        data.friendlyFireEnabled = defaultFriendly
     end
 
     BanditTweaks._modData = data

--- a/BanditTweaks/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/BanditTweaks/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -1,0 +1,17 @@
+Sandbox_EN = {
+
+    Sandbox_BanditTweaks = "Bandit Tweaks",
+
+    Sandbox_BanditTweaks.SpawnDistanceMultiplier = "Spawn distance multiplier",
+    Sandbox_BanditTweaks.SpawnDistanceMultiplier_tooltip = "Multiplies the base distance used when spawning bandits.",
+
+    Sandbox_BanditTweaks.HostileSpawnChanceMultiplier = "Hostile clan spawn chance multiplier",
+    Sandbox_BanditTweaks.HostileSpawnChanceMultiplier_tooltip = "Scales the spawn chance applied to hostile bandit clans.",
+
+    Sandbox_BanditTweaks.HostileEventChance = "Hostile bandit event chance",
+    Sandbox_BanditTweaks.HostileEventChance_tooltip = "Chance that scripted hostile bandit events will occur.",
+
+    Sandbox_BanditTweaks.FriendlyFireEnabled = "Friendly fire enabled by default",
+    Sandbox_BanditTweaks.FriendlyFireEnabled_tooltip = "Initial state for friendly fire. Can still be toggled in-game via the context menu.",
+
+}

--- a/BanditTweaks/media/sandbox-options.txt
+++ b/BanditTweaks/media/sandbox-options.txt
@@ -1,0 +1,21 @@
+VERSION = 1,
+
+option BanditTweaks.SpawnDistanceMultiplier = {
+    type = double, min = 0.25, max = 5, default = 1.50,
+    page = BanditTweaks, translation = BanditTweaks.SpawnDistanceMultiplier, _tooltip = BanditTweaks.SpawnDistanceMultiplier_tooltip,
+}
+
+option BanditTweaks.HostileSpawnChanceMultiplier = {
+    type = double, min = 0.00, max = 2, default = 0.10,
+    page = BanditTweaks, translation = BanditTweaks.HostileSpawnChanceMultiplier, _tooltip = BanditTweaks.HostileSpawnChanceMultiplier_tooltip,
+}
+
+option BanditTweaks.HostileEventChance = {
+    type = double, min = 0.00, max = 1, default = 0.10,
+    page = BanditTweaks, translation = BanditTweaks.HostileEventChance, _tooltip = BanditTweaks.HostileEventChance_tooltip,
+}
+
+option BanditTweaks.FriendlyFireEnabled = {
+    type = boolean, default = true,
+    page = BanditTweaks, translation = BanditTweaks.FriendlyFireEnabled, _tooltip = BanditTweaks.FriendlyFireEnabled_tooltip,
+}


### PR DESCRIPTION
## Summary
- add sandbox options so Bandit Tweaks multipliers and friendly fire default can be configured in-game
- refresh tweak configuration from sandbox values on load and expose translations for the new settings

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2ba70f4a88332a075521a7c4048a8