### PR TITLE
Prevent indicator panel from blocking UI

### DIFF
--- a/BanditTweaks/42/media/lua/client/BanditTweaksClient.lua
+++ b/BanditTweaks/42/media/lua/client/BanditTweaksClient.lua
@@ -124,6 +124,7 @@ local function ensureIndicatorPanel()
     panel:setAnchorRight(true)
     panel:setAnchorBottom(true)
     panel:setAlwaysOnTop(true)
+    panel.bConsumeMouseEvents = false
 
     function panel:render()
         if not isIngameState() then

--- a/BanditTweaks/media/lua/client/BanditTweaksClient.lua
+++ b/BanditTweaks/media/lua/client/BanditTweaksClient.lua
@@ -124,6 +124,7 @@ local function ensureIndicatorPanel()
     panel:setAnchorRight(true)
     panel:setAnchorBottom(true)
     panel:setAlwaysOnTop(true)
+    panel.bConsumeMouseEvents = false
 
     function panel:render()
         if not isIngameState() then


### PR DESCRIPTION
## Summary
- stop the indicator overlay panel from consuming mouse events so the rest of the UI stays clickable

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2bae281bc83329954555424a9159b