### PR TITLE
Render hostile indicators without blocking input

### DIFF
--- a/BanditTweaks/42/media/lua/client/BanditTweaksClient.lua
+++ b/BanditTweaks/42/media/lua/client/BanditTweaksClient.lua
@@ -6,6 +6,18 @@ require "ISUI/ISUIElement"
 local trackedHostiles = {}
 local trackedFriendlyHealth = {}
 
+local function removeLegacyIndicatorPanel()
+    local panel = BanditTweaks and BanditTweaks.IndicatorPanel
+    if panel then
+        if panel.removeFromUIManager then
+            panel:removeFromUIManager()
+        end
+        BanditTweaks.IndicatorPanel = nil
+    end
+end
+
+removeLegacyIndicatorPanel()
+
 local function clearFriendlyHealth()
     for zombie in pairs(trackedFriendlyHealth) do
         trackedFriendlyHealth[zombie] = nil
@@ -116,6 +128,8 @@ local indicatorRenderer = ISUIElement:new(0, 0, 0, 0)
 indicatorRenderer:initialise()
 
 local function renderIndicatorOverlay()
+    removeLegacyIndicatorPanel()
+
     if not isIngameState() then
         return
     end

--- a/BanditTweaks/media/lua/client/BanditTweaksClient.lua
+++ b/BanditTweaks/media/lua/client/BanditTweaksClient.lua
@@ -6,6 +6,18 @@ require "ISUI/ISUIElement"
 local trackedHostiles = {}
 local trackedFriendlyHealth = {}
 
+local function removeLegacyIndicatorPanel()
+    local panel = BanditTweaks and BanditTweaks.IndicatorPanel
+    if panel then
+        if panel.removeFromUIManager then
+            panel:removeFromUIManager()
+        end
+        BanditTweaks.IndicatorPanel = nil
+    end
+end
+
+removeLegacyIndicatorPanel()
+
 local function clearFriendlyHealth()
     for zombie in pairs(trackedFriendlyHealth) do
         trackedFriendlyHealth[zombie] = nil
@@ -116,6 +128,8 @@ local indicatorRenderer = ISUIElement:new(0, 0, 0, 0)
 indicatorRenderer:initialise()
 
 local function renderIndicatorOverlay()
+    removeLegacyIndicatorPanel()
+
     if not isIngameState() then
         return
     end


### PR DESCRIPTION
## Summary
- draw the hostile markers during the post-UI render pass instead of a full-screen UI panel
- reuse a lightweight ISUIElement purely for drawing so no mouse or wheel events are captured

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2bae281bc83329954555424a9159b