### PR TITLE
Add configurable enemy indicator options

### DIFF
--- a/BanditTweaks/media/lua/client/BanditTweaksClient.lua
+++ b/BanditTweaks/media/lua/client/BanditTweaksClient.lua
@@ -27,23 +27,57 @@ function BanditTweaks.ToggleFriendlyFire()
     end
 end
 
-local function addFriendlyFireOption(playerNum, context, worldobjects, test)
-    local label
-    if BanditTweaks.Config.friendlyFireEnabled then
-        label = "Disable Friendly Fire"
-    else
-        label = "Enable Friendly Fire"
-    end
+function BanditTweaks.ToggleEnemyIndicators()
+    local newState = not BanditTweaks.Config.indicatorEnabled
+    BanditTweaks.SetIndicatorEnabled(newState)
 
-    local option = context:addOption("[Bandit Tweaks] " .. label, worldobjects, BanditTweaks.ToggleFriendlyFire)
-    if option then
+    local player = getSpecificPlayer(0)
+    if player then
+        local message = newState and "Enemy indicators enabled" or "Enemy indicators disabled"
+        player:Say(message)
+    end
+end
+
+function BanditTweaks.ToggleIndicatorStyle()
+    local outline = not BanditTweaks.Config.indicatorOutline
+    BanditTweaks.SetIndicatorOutline(outline)
+
+    local player = getSpecificPlayer(0)
+    if player then
+        local message = outline and "Enemy indicators set to outline" or "Enemy indicators set to filled"
+        player:Say(message)
+    end
+end
+
+local function addBanditTweaksOptions(playerNum, context, worldobjects, test)
+    local friendlyLabel = BanditTweaks.Config.friendlyFireEnabled and "Disable Friendly Fire" or "Enable Friendly Fire"
+    local friendlyOption = context:addOption("[Bandit Tweaks] " .. friendlyLabel, worldobjects, BanditTweaks.ToggleFriendlyFire)
+    if friendlyOption then
         local toolTip = ISWorldObjectContextMenu.addToolTip()
         toolTip.description = "When disabled you cannot damage friendly bandits."
         toolTip:setName("Enable Friendly Fire")
-        option.toolTip = toolTip
+        friendlyOption.toolTip = toolTip
+    end
+
+    local indicatorLabel = BanditTweaks.Config.indicatorEnabled and "Disable Enemy Indicators" or "Enable Enemy Indicators"
+    local indicatorOption = context:addOption("[Bandit Tweaks] " .. indicatorLabel, worldobjects, BanditTweaks.ToggleEnemyIndicators)
+    if indicatorOption then
+        local toolTip = ISWorldObjectContextMenu.addToolTip()
+        toolTip.description = "Show or hide the hostile bandit indicator above enemies."
+        toolTip:setName("Enemy Indicator")
+        indicatorOption.toolTip = toolTip
+    end
+
+    local styleLabel = BanditTweaks.Config.indicatorOutline and "Use Filled Enemy Indicator" or "Use Outline Enemy Indicator"
+    local styleOption = context:addOption("[Bandit Tweaks] " .. styleLabel, worldobjects, BanditTweaks.ToggleIndicatorStyle)
+    if styleOption then
+        local toolTip = ISWorldObjectContextMenu.addToolTip()
+        toolTip.description = "Switch between a filled or outline indicator for hostile bandits."
+        toolTip:setName("Enemy Indicator Style")
+        styleOption.toolTip = toolTip
     end
 end
-Events.OnFillWorldObjectContextMenu.Add(addFriendlyFireOption)
+Events.OnFillWorldObjectContextMenu.Add(addBanditTweaksOptions)
 
 local function shouldTrackFriendly()
     return not BanditTweaks.Config.friendlyFireEnabled
@@ -136,17 +170,39 @@ local function ensureIndicatorPanel()
             return
         end
 
+        if not BanditTweaks.Config.indicatorEnabled then
+            return
+        end
+
         local zoom = getCore():getZoom(player:getPlayerNum())
         local size = math.max(4, math.floor(10 / zoom))
         local verticalOffset = 85 / zoom
 
         for zombie in pairs(trackedHostiles) do
             if zombie and not zombie:isDead() then
-                local screenX, screenY = ISCoordConversion.ToScreen(zombie:getX(), zombie:getY(), zombie:getZ())
-                local drawX = screenX / zoom - size / 2
-                local drawY = screenY / zoom - verticalOffset - size
-                self:drawRect(drawX, drawY, size, size, 0.85, 1, 0, 0)
-                self:drawRectBorder(drawX, drawY, size, size, 1, 0.35, 0, 0)
+                local canSee = false
+                if player.CanSee then
+                    canSee = player:CanSee(zombie) and true or false
+                end
+
+                if not canSee and player.canSeeSquare then
+                    local square = zombie:getCurrentSquare()
+                    if square then
+                        canSee = player:canSeeSquare(square)
+                    end
+                end
+
+                if canSee then
+                    local screenX, screenY = ISCoordConversion.ToScreen(zombie:getX(), zombie:getY(), zombie:getZ())
+                    local drawX = screenX / zoom - size / 2
+                    local drawY = screenY / zoom - verticalOffset - size
+                    if BanditTweaks.Config.indicatorOutline then
+                        self:drawRectBorder(drawX, drawY, size, size, 1, 1, 0, 0)
+                    else
+                        self:drawRect(drawX, drawY, size, size, 0.85, 1, 0, 0)
+                        self:drawRectBorder(drawX, drawY, size, size, 1, 0.35, 0, 0)
+                    end
+                end
             end
         end
     end

--- a/BanditTweaks/media/lua/shared/BanditTweaksShared.lua
+++ b/BanditTweaks/media/lua/shared/BanditTweaksShared.lua
@@ -6,11 +6,15 @@ BanditTweaks.Defaults.spawnDistanceMultiplier = 1.5
 BanditTweaks.Defaults.hostileSpawnChanceMultiplier = 0.1
 BanditTweaks.Defaults.hostileEventChance = 0.1
 BanditTweaks.Defaults.friendlyFireEnabled = true
+BanditTweaks.Defaults.indicatorEnabled = true
+BanditTweaks.Defaults.indicatorOutline = false
 
 BanditTweaks.Config.spawnDistanceMultiplier = BanditTweaks.Config.spawnDistanceMultiplier or BanditTweaks.Defaults.spawnDistanceMultiplier
 BanditTweaks.Config.hostileSpawnChanceMultiplier = BanditTweaks.Config.hostileSpawnChanceMultiplier or BanditTweaks.Defaults.hostileSpawnChanceMultiplier
 BanditTweaks.Config.hostileEventChance = BanditTweaks.Config.hostileEventChance or BanditTweaks.Defaults.hostileEventChance
 BanditTweaks.Config.friendlyFireEnabled = BanditTweaks.Config.friendlyFireEnabled ~= false
+BanditTweaks.Config.indicatorEnabled = BanditTweaks.Config.indicatorEnabled ~= false
+BanditTweaks.Config.indicatorOutline = BanditTweaks.Config.indicatorOutline == true
 
 local function getSandboxNumber(options, key, default)
     local value = options and options[key]
@@ -20,11 +24,26 @@ local function getSandboxNumber(options, key, default)
     return default
 end
 
+local function getSandboxBoolean(options, key, default)
+    if not options then
+        return default
+    end
+
+    local value = options[key]
+    if value == nil then
+        return default
+    end
+
+    return value and true or false
+end
+
 function BanditTweaks.UpdateConfigFromSandbox()
     local options = SandboxVars and SandboxVars.BanditTweaks
     BanditTweaks.Config.spawnDistanceMultiplier = getSandboxNumber(options, "SpawnDistanceMultiplier", BanditTweaks.Defaults.spawnDistanceMultiplier)
     BanditTweaks.Config.hostileSpawnChanceMultiplier = getSandboxNumber(options, "HostileSpawnChanceMultiplier", BanditTweaks.Defaults.hostileSpawnChanceMultiplier)
     BanditTweaks.Config.hostileEventChance = getSandboxNumber(options, "HostileEventChance", BanditTweaks.Defaults.hostileEventChance)
+    BanditTweaks.Config.indicatorEnabled = getSandboxBoolean(options, "IndicatorEnabled", BanditTweaks.Defaults.indicatorEnabled)
+    BanditTweaks.Config.indicatorOutline = getSandboxBoolean(options, "IndicatorOutline", BanditTweaks.Defaults.indicatorOutline)
 end
 
 BanditTweaks.UpdateConfigFromSandbox()
@@ -72,17 +91,36 @@ local function loadModData(isNewGame)
         ModData.request(BanditTweaks._dataKey)
     end
 
+    local options = SandboxVars and SandboxVars.BanditTweaks
+
     if data.friendlyFireEnabled == nil then
         local defaultFriendly = BanditTweaks.Defaults.friendlyFireEnabled
-        local options = SandboxVars and SandboxVars.BanditTweaks
         if options and options.FriendlyFireEnabled ~= nil then
             defaultFriendly = options.FriendlyFireEnabled and true or false
         end
         data.friendlyFireEnabled = defaultFriendly
     end
 
+    if data.indicatorEnabled == nil then
+        local defaultIndicator = BanditTweaks.Defaults.indicatorEnabled
+        if options and options.IndicatorEnabled ~= nil then
+            defaultIndicator = options.IndicatorEnabled and true or false
+        end
+        data.indicatorEnabled = defaultIndicator
+    end
+
+    if data.indicatorOutline == nil then
+        local defaultOutline = BanditTweaks.Defaults.indicatorOutline
+        if options and options.IndicatorOutline ~= nil then
+            defaultOutline = options.IndicatorOutline and true or false
+        end
+        data.indicatorOutline = defaultOutline
+    end
+
     BanditTweaks._modData = data
     BanditTweaks.Config.friendlyFireEnabled = data.friendlyFireEnabled ~= false
+    BanditTweaks.Config.indicatorEnabled = data.indicatorEnabled ~= false
+    BanditTweaks.Config.indicatorOutline = data.indicatorOutline == true
 end
 Events.OnInitGlobalModData.Add(loadModData)
 
@@ -90,6 +128,8 @@ local function receiveModData(key, data)
     if key == BanditTweaks._dataKey and data then
         BanditTweaks._modData = data
         BanditTweaks.Config.friendlyFireEnabled = data.friendlyFireEnabled ~= false
+        BanditTweaks.Config.indicatorEnabled = data.indicatorEnabled ~= false
+        BanditTweaks.Config.indicatorOutline = data.indicatorOutline == true
     end
 end
 Events.OnReceiveGlobalModData.Add(receiveModData)
@@ -100,6 +140,30 @@ function BanditTweaks.SetFriendlyFireEnabled(enabled)
 
     if BanditTweaks._modData then
         BanditTweaks._modData.friendlyFireEnabled = enabled
+        if isServer() then
+            ModData.transmit(BanditTweaks._dataKey)
+        end
+    end
+end
+
+function BanditTweaks.SetIndicatorEnabled(enabled)
+    enabled = enabled and true or false
+    BanditTweaks.Config.indicatorEnabled = enabled
+
+    if BanditTweaks._modData then
+        BanditTweaks._modData.indicatorEnabled = enabled
+        if isServer() then
+            ModData.transmit(BanditTweaks._dataKey)
+        end
+    end
+end
+
+function BanditTweaks.SetIndicatorOutline(outline)
+    outline = outline and true or false
+    BanditTweaks.Config.indicatorOutline = outline
+
+    if BanditTweaks._modData then
+        BanditTweaks._modData.indicatorOutline = outline
         if isServer() then
             ModData.transmit(BanditTweaks._dataKey)
         end

--- a/BanditTweaks/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/BanditTweaks/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -14,4 +14,10 @@ Sandbox_EN = {
     Sandbox_BanditTweaks.FriendlyFireEnabled = "Friendly fire enabled by default",
     Sandbox_BanditTweaks.FriendlyFireEnabled_tooltip = "Initial state for friendly fire. Can still be toggled in-game via the context menu.",
 
+    Sandbox_BanditTweaks.IndicatorEnabled = "Enemy indicator enabled by default",
+    Sandbox_BanditTweaks.IndicatorEnabled_tooltip = "Controls whether hostile bandit indicators are visible.",
+
+    Sandbox_BanditTweaks.IndicatorOutline = "Use outline enemy indicator",
+    Sandbox_BanditTweaks.IndicatorOutline_tooltip = "Draw hostile bandit indicators as outlines instead of filled squares.",
+
 }

--- a/BanditTweaks/media/sandbox-options.txt
+++ b/BanditTweaks/media/sandbox-options.txt
@@ -19,3 +19,13 @@ option BanditTweaks.FriendlyFireEnabled = {
     type = boolean, default = true,
     page = BanditTweaks, translation = BanditTweaks.FriendlyFireEnabled, _tooltip = BanditTweaks.FriendlyFireEnabled_tooltip,
 }
+
+option BanditTweaks.IndicatorEnabled = {
+    type = boolean, default = true,
+    page = BanditTweaks, translation = BanditTweaks.IndicatorEnabled, _tooltip = BanditTweaks.IndicatorEnabled_tooltip,
+}
+
+option BanditTweaks.IndicatorOutline = {
+    type = boolean, default = false,
+    page = BanditTweaks, translation = BanditTweaks.IndicatorOutline, _tooltip = BanditTweaks.IndicatorOutline_tooltip,
+}


### PR DESCRIPTION
## Summary
- add sandbox-backed settings for enemy indicator visibility and outline style and persist them in mod data
- expose new toggle and style options through the in-game Bandit Tweaks context menu
- stop drawing hostile indicators when outside the player's field of view and honor outline mode when rendering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2c3b07ddc8332b651f053804efd69