### PR TITLE
Add Day One civilian distance and starter toggle

### DIFF
--- a/BanditTweaks/42/media/lua/client/BanditTweaksClient.lua
+++ b/BanditTweaks/42/media/lua/client/BanditTweaksClient.lua
@@ -188,6 +188,63 @@ Events.OnTick.Add(patchFriendlyFireCheck)
 
 local hostilePhaseNames = {"SpawnGang", "SpawnBandits", "SpawnInmates"}
 
+local function cloneSpawnPoint(point)
+    if not point then
+        return nil
+    end
+    return {x = point.x, y = point.y, z = point.z}
+end
+
+local function normalizeSpawnPoint(spawnPoint)
+    if type(spawnPoint) ~= "table" then
+        return nil
+    end
+
+    if spawnPoint.x and spawnPoint.y then
+        return cloneSpawnPoint(spawnPoint)
+    end
+
+    for _, value in pairs(spawnPoint) do
+        if type(value) == "table" and value.x and value.y then
+            return cloneSpawnPoint(value)
+        end
+    end
+
+    return nil
+end
+
+local function isSpawnPointFarEnough(player, point, minDistance)
+    if not player or not point or not minDistance then
+        return false
+    end
+
+    local px, py = player:getX(), player:getY()
+    local dx, dy = point.x - px, point.y - py
+    return (dx * dx + dy * dy) >= (minDistance * minDistance)
+end
+
+local function findDayOneStarterSpawnPoint(player)
+    if not player or not BanditScheduler or not BanditScheduler.GenerateSpawnPoint then
+        return nil
+    end
+
+    local baseDistance = BanditTweaks.Config.dayOneStarterMinDistance or BanditTweaks.Defaults.dayOneStarterMinDistance or 35
+    local attempts = {baseDistance + 15, baseDistance + 5, baseDistance}
+
+    for _, dist in ipairs(attempts) do
+        local rawPoint = BanditScheduler.GenerateSpawnPoint(player, dist)
+        local point = normalizeSpawnPoint(rawPoint)
+        if point then
+            point.z = point.z or player:getZ()
+            if isSpawnPointFarEnough(player, point, baseDistance) then
+                return point
+            end
+        end
+    end
+
+    return nil
+end
+
 local function tryPatchDayOne()
     if BanditTweaks._dayOnePatched then
         Events.OnTick.Remove(tryPatchDayOne)
@@ -216,6 +273,48 @@ local function tryPatchDayOne()
                 patchedSomething = true
             end
         end
+
+        if not BanditTweaks._patchedDayOneFamily and type(DOPhases.SpawnFamilly) == "function" then
+            DOPhases.SpawnFamilly = function(player, ...)
+                if not player then
+                    return
+                end
+
+                if not BanditTweaks.Config.dayOneStarterEnabled then
+                    return
+                end
+
+                local spawnPoint = findDayOneStarterSpawnPoint(player)
+                if not spawnPoint then
+                    return
+                end
+
+                local config = {}
+                config.clanId = 1
+                config.hasRifleChance = 0
+                config.hasPistolChance = 0
+                config.rifleMagCount = 0
+                config.pistolMagCount = 0
+
+                local event = {}
+                event.hostile = false
+                event.occured = false
+                event.program = {name = "Companion", stage = "Prepare"}
+                event.x = spawnPoint.x
+                event.y = spawnPoint.y
+                event.z = spawnPoint.z or player:getZ()
+                event.bandits = {}
+
+                local bandit = BanditCreator.MakeFromWave(config)
+                table.insert(event.bandits, bandit)
+                table.insert(event.bandits, bandit)
+
+                addSound(player, event.x, event.y, event.z, 40, 100)
+                sendClientCommand(player, 'Commands', 'SpawnGroup', event)
+            end
+            BanditTweaks._patchedDayOneFamily = true
+            patchedSomething = true
+        end
     end
 
     if BanditScheduler and BanditScheduler.GenerateSpawnPoint and not BanditTweaks._patchedScheduler then
@@ -230,7 +329,7 @@ local function tryPatchDayOne()
         patchedSomething = true
     end
 
-    local allPatched = BanditTweaks._patchedScheduler
+    local allPatched = BanditTweaks._patchedScheduler and BanditTweaks._patchedDayOneFamily
     for _, name in ipairs(hostilePhaseNames) do
         allPatched = allPatched and BanditTweaks["_patchedPhase" .. name]
     end

--- a/BanditTweaks/42/media/lua/shared/BanditTweaksShared.lua
+++ b/BanditTweaks/42/media/lua/shared/BanditTweaksShared.lua
@@ -6,11 +6,15 @@ BanditTweaks.Defaults.spawnDistanceMultiplier = 1.5
 BanditTweaks.Defaults.hostileSpawnChanceMultiplier = 0.1
 BanditTweaks.Defaults.hostileEventChance = 0.1
 BanditTweaks.Defaults.friendlyFireEnabled = true
+BanditTweaks.Defaults.dayOneStarterEnabled = false
+BanditTweaks.Defaults.dayOneStarterMinDistance = 35
 
 BanditTweaks.Config.spawnDistanceMultiplier = BanditTweaks.Config.spawnDistanceMultiplier or BanditTweaks.Defaults.spawnDistanceMultiplier
 BanditTweaks.Config.hostileSpawnChanceMultiplier = BanditTweaks.Config.hostileSpawnChanceMultiplier or BanditTweaks.Defaults.hostileSpawnChanceMultiplier
 BanditTweaks.Config.hostileEventChance = BanditTweaks.Config.hostileEventChance or BanditTweaks.Defaults.hostileEventChance
 BanditTweaks.Config.friendlyFireEnabled = BanditTweaks.Config.friendlyFireEnabled ~= false
+BanditTweaks.Config.dayOneStarterEnabled = BanditTweaks.Config.dayOneStarterEnabled or BanditTweaks.Defaults.dayOneStarterEnabled
+BanditTweaks.Config.dayOneStarterMinDistance = BanditTweaks.Config.dayOneStarterMinDistance or BanditTweaks.Defaults.dayOneStarterMinDistance
 
 local function getSandboxNumber(options, key, default)
     local value = options and options[key]
@@ -20,11 +24,19 @@ local function getSandboxNumber(options, key, default)
     return default
 end
 
+local function getSandboxBoolean(options, key, default)
+    if options and options[key] ~= nil then
+        return options[key] and true or false
+    end
+    return default
+end
+
 function BanditTweaks.UpdateConfigFromSandbox()
     local options = SandboxVars and SandboxVars.BanditTweaks
     BanditTweaks.Config.spawnDistanceMultiplier = getSandboxNumber(options, "SpawnDistanceMultiplier", BanditTweaks.Defaults.spawnDistanceMultiplier)
     BanditTweaks.Config.hostileSpawnChanceMultiplier = getSandboxNumber(options, "HostileSpawnChanceMultiplier", BanditTweaks.Defaults.hostileSpawnChanceMultiplier)
     BanditTweaks.Config.hostileEventChance = getSandboxNumber(options, "HostileEventChance", BanditTweaks.Defaults.hostileEventChance)
+    BanditTweaks.Config.dayOneStarterEnabled = getSandboxBoolean(options, "DayOneStartingCivilians", BanditTweaks.Defaults.dayOneStarterEnabled)
 end
 
 BanditTweaks.UpdateConfigFromSandbox()

--- a/BanditTweaks/42/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/BanditTweaks/42/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -14,4 +14,7 @@ Sandbox_EN = {
     Sandbox_BanditTweaks.FriendlyFireEnabled = "Friendly fire enabled by default",
     Sandbox_BanditTweaks.FriendlyFireEnabled_tooltip = "Initial state for friendly fire. Can still be toggled in-game via the context menu.",
 
+    Sandbox_BanditTweaks.DayOneStartingCivilians = "Day One starter civilians",
+    Sandbox_BanditTweaks.DayOneStartingCivilians_tooltip = "Enable the friendly civilians that spawn with you in Bandits Day One. When enabled they arrive at a safe distance.",
+
 }

--- a/BanditTweaks/42/media/sandbox-options.txt
+++ b/BanditTweaks/42/media/sandbox-options.txt
@@ -19,3 +19,8 @@ option BanditTweaks.FriendlyFireEnabled = {
     type = boolean, default = true,
     page = BanditTweaks, translation = BanditTweaks.FriendlyFireEnabled, _tooltip = BanditTweaks.FriendlyFireEnabled_tooltip,
 }
+
+option BanditTweaks.DayOneStartingCivilians = {
+    type = boolean, default = false,
+    page = BanditTweaks, translation = BanditTweaks.DayOneStartingCivilians, _tooltip = BanditTweaks.DayOneStartingCivilians_tooltip,
+}

--- a/BanditTweaks/media/lua/client/BanditTweaksClient.lua
+++ b/BanditTweaks/media/lua/client/BanditTweaksClient.lua
@@ -188,6 +188,63 @@ Events.OnTick.Add(patchFriendlyFireCheck)
 
 local hostilePhaseNames = {"SpawnGang", "SpawnBandits", "SpawnInmates"}
 
+local function cloneSpawnPoint(point)
+    if not point then
+        return nil
+    end
+    return {x = point.x, y = point.y, z = point.z}
+end
+
+local function normalizeSpawnPoint(spawnPoint)
+    if type(spawnPoint) ~= "table" then
+        return nil
+    end
+
+    if spawnPoint.x and spawnPoint.y then
+        return cloneSpawnPoint(spawnPoint)
+    end
+
+    for _, value in pairs(spawnPoint) do
+        if type(value) == "table" and value.x and value.y then
+            return cloneSpawnPoint(value)
+        end
+    end
+
+    return nil
+end
+
+local function isSpawnPointFarEnough(player, point, minDistance)
+    if not player or not point or not minDistance then
+        return false
+    end
+
+    local px, py = player:getX(), player:getY()
+    local dx, dy = point.x - px, point.y - py
+    return (dx * dx + dy * dy) >= (minDistance * minDistance)
+end
+
+local function findDayOneStarterSpawnPoint(player)
+    if not player or not BanditScheduler or not BanditScheduler.GenerateSpawnPoint then
+        return nil
+    end
+
+    local baseDistance = BanditTweaks.Config.dayOneStarterMinDistance or BanditTweaks.Defaults.dayOneStarterMinDistance or 35
+    local attempts = {baseDistance + 15, baseDistance + 5, baseDistance}
+
+    for _, dist in ipairs(attempts) do
+        local rawPoint = BanditScheduler.GenerateSpawnPoint(player, dist)
+        local point = normalizeSpawnPoint(rawPoint)
+        if point then
+            point.z = point.z or player:getZ()
+            if isSpawnPointFarEnough(player, point, baseDistance) then
+                return point
+            end
+        end
+    end
+
+    return nil
+end
+
 local function tryPatchDayOne()
     if BanditTweaks._dayOnePatched then
         Events.OnTick.Remove(tryPatchDayOne)
@@ -216,6 +273,48 @@ local function tryPatchDayOne()
                 patchedSomething = true
             end
         end
+
+        if not BanditTweaks._patchedDayOneFamily and type(DOPhases.SpawnFamilly) == "function" then
+            DOPhases.SpawnFamilly = function(player, ...)
+                if not player then
+                    return
+                end
+
+                if not BanditTweaks.Config.dayOneStarterEnabled then
+                    return
+                end
+
+                local spawnPoint = findDayOneStarterSpawnPoint(player)
+                if not spawnPoint then
+                    return
+                end
+
+                local config = {}
+                config.clanId = 1
+                config.hasRifleChance = 0
+                config.hasPistolChance = 0
+                config.rifleMagCount = 0
+                config.pistolMagCount = 0
+
+                local event = {}
+                event.hostile = false
+                event.occured = false
+                event.program = {name = "Companion", stage = "Prepare"}
+                event.x = spawnPoint.x
+                event.y = spawnPoint.y
+                event.z = spawnPoint.z or player:getZ()
+                event.bandits = {}
+
+                local bandit = BanditCreator.MakeFromWave(config)
+                table.insert(event.bandits, bandit)
+                table.insert(event.bandits, bandit)
+
+                addSound(player, event.x, event.y, event.z, 40, 100)
+                sendClientCommand(player, 'Commands', 'SpawnGroup', event)
+            end
+            BanditTweaks._patchedDayOneFamily = true
+            patchedSomething = true
+        end
     end
 
     if BanditScheduler and BanditScheduler.GenerateSpawnPoint and not BanditTweaks._patchedScheduler then
@@ -230,7 +329,7 @@ local function tryPatchDayOne()
         patchedSomething = true
     end
 
-    local allPatched = BanditTweaks._patchedScheduler
+    local allPatched = BanditTweaks._patchedScheduler and BanditTweaks._patchedDayOneFamily
     for _, name in ipairs(hostilePhaseNames) do
         allPatched = allPatched and BanditTweaks["_patchedPhase" .. name]
     end

--- a/BanditTweaks/media/lua/shared/BanditTweaksShared.lua
+++ b/BanditTweaks/media/lua/shared/BanditTweaksShared.lua
@@ -6,11 +6,15 @@ BanditTweaks.Defaults.spawnDistanceMultiplier = 1.5
 BanditTweaks.Defaults.hostileSpawnChanceMultiplier = 0.1
 BanditTweaks.Defaults.hostileEventChance = 0.1
 BanditTweaks.Defaults.friendlyFireEnabled = true
+BanditTweaks.Defaults.dayOneStarterEnabled = false
+BanditTweaks.Defaults.dayOneStarterMinDistance = 35
 
 BanditTweaks.Config.spawnDistanceMultiplier = BanditTweaks.Config.spawnDistanceMultiplier or BanditTweaks.Defaults.spawnDistanceMultiplier
 BanditTweaks.Config.hostileSpawnChanceMultiplier = BanditTweaks.Config.hostileSpawnChanceMultiplier or BanditTweaks.Defaults.hostileSpawnChanceMultiplier
 BanditTweaks.Config.hostileEventChance = BanditTweaks.Config.hostileEventChance or BanditTweaks.Defaults.hostileEventChance
 BanditTweaks.Config.friendlyFireEnabled = BanditTweaks.Config.friendlyFireEnabled ~= false
+BanditTweaks.Config.dayOneStarterEnabled = BanditTweaks.Config.dayOneStarterEnabled or BanditTweaks.Defaults.dayOneStarterEnabled
+BanditTweaks.Config.dayOneStarterMinDistance = BanditTweaks.Config.dayOneStarterMinDistance or BanditTweaks.Defaults.dayOneStarterMinDistance
 
 local function getSandboxNumber(options, key, default)
     local value = options and options[key]
@@ -20,11 +24,19 @@ local function getSandboxNumber(options, key, default)
     return default
 end
 
+local function getSandboxBoolean(options, key, default)
+    if options and options[key] ~= nil then
+        return options[key] and true or false
+    end
+    return default
+end
+
 function BanditTweaks.UpdateConfigFromSandbox()
     local options = SandboxVars and SandboxVars.BanditTweaks
     BanditTweaks.Config.spawnDistanceMultiplier = getSandboxNumber(options, "SpawnDistanceMultiplier", BanditTweaks.Defaults.spawnDistanceMultiplier)
     BanditTweaks.Config.hostileSpawnChanceMultiplier = getSandboxNumber(options, "HostileSpawnChanceMultiplier", BanditTweaks.Defaults.hostileSpawnChanceMultiplier)
     BanditTweaks.Config.hostileEventChance = getSandboxNumber(options, "HostileEventChance", BanditTweaks.Defaults.hostileEventChance)
+    BanditTweaks.Config.dayOneStarterEnabled = getSandboxBoolean(options, "DayOneStartingCivilians", BanditTweaks.Defaults.dayOneStarterEnabled)
 end
 
 BanditTweaks.UpdateConfigFromSandbox()

--- a/BanditTweaks/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/BanditTweaks/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -14,4 +14,7 @@ Sandbox_EN = {
     Sandbox_BanditTweaks.FriendlyFireEnabled = "Friendly fire enabled by default",
     Sandbox_BanditTweaks.FriendlyFireEnabled_tooltip = "Initial state for friendly fire. Can still be toggled in-game via the context menu.",
 
+    Sandbox_BanditTweaks.DayOneStartingCivilians = "Day One starter civilians",
+    Sandbox_BanditTweaks.DayOneStartingCivilians_tooltip = "Enable the friendly civilians that spawn with you in Bandits Day One. When enabled they arrive at a safe distance.",
+
 }

--- a/BanditTweaks/media/sandbox-options.txt
+++ b/BanditTweaks/media/sandbox-options.txt
@@ -19,3 +19,8 @@ option BanditTweaks.FriendlyFireEnabled = {
     type = boolean, default = true,
     page = BanditTweaks, translation = BanditTweaks.FriendlyFireEnabled, _tooltip = BanditTweaks.FriendlyFireEnabled_tooltip,
 }
+
+option BanditTweaks.DayOneStartingCivilians = {
+    type = boolean, default = false,
+    page = BanditTweaks, translation = BanditTweaks.DayOneStartingCivilians, _tooltip = BanditTweaks.DayOneStartingCivilians_tooltip,
+}


### PR DESCRIPTION
## Summary
- add a sandbox toggle for spawning friendly Day One civilians, defaulting them to off
- ensure Day One starter civilians spawn at a safe distance when enabled
- extend BanditTweaks defaults/config to expose the new option

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2c4b85a24833297a297a72a4fca2b