### PR TITLE
Prevent indicator overlay from blocking UI

### DIFF
--- a/BanditTweaks/42/media/lua/client/BanditTweaksClient.lua
+++ b/BanditTweaks/42/media/lua/client/BanditTweaksClient.lua
@@ -126,6 +126,43 @@ local function ensureIndicatorPanel()
     panel:setAlwaysOnTop(true)
     panel.bConsumeMouseEvents = false
 
+    -- Prevent the overlay from blocking normal UI input.
+    function panel:isMouseOver()
+        return false
+    end
+
+    function panel:isPointOver(x, y)
+        return false
+    end
+
+    function panel:onMouseDown(x, y)
+        return false
+    end
+
+    function panel:onMouseUp(x, y)
+        return false
+    end
+
+    function panel:onRightMouseDown(x, y)
+        return false
+    end
+
+    function panel:onRightMouseUp(x, y)
+        return false
+    end
+
+    function panel:onMouseMove(dx, dy)
+        return false
+    end
+
+    function panel:onMouseMoveOutside(dx, dy)
+        return false
+    end
+
+    function panel:onMouseWheel(del)
+        return false
+    end
+
     function panel:render()
         if not isIngameState() then
             return


### PR DESCRIPTION
## Summary
- ensure the hostile indicator overlay no longer consumes mouse input by overriding its handlers to return false

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2cc6883f88332870b6ba62235344b