### PR TITLE
Separate civilian fighters and cowards into dedicated clans

### DIFF
--- a/BanditTweaks/42/media/lua/client/BanditTweaks/Features/CivilianBehavior.lua
+++ b/BanditTweaks/42/media/lua/client/BanditTweaks/Features/CivilianBehavior.lua
@@ -2,13 +2,18 @@ if isServer() then return end
 
 local CivilianBehavior = {}
 
-local CIVILIAN_CID = "c167d1e0-c077-4ee5-b353-88b374de193d"
+local CivilianGroups = require "BanditTweaks/CivilianGroups"
+local CIVILIAN_FIGHTER_CID = CivilianGroups.FIGHTER_CID
+local CIVILIAN_COWARD_CID = CivilianGroups.COWARD_CID
+
 CivilianBehavior.CIVILIAN_ROLE_KEY = "BanditTweaksCivilianRole"
 CivilianBehavior.ROLE_FIGHTER = "fighter"
 CivilianBehavior.ROLE_COWARD = "coward"
 CivilianBehavior.ROLE_HIDER = "hider"
 CivilianBehavior.ROLE_PANICKED = "panicked"
 CivilianBehavior.ROLE_SHADOW = "shadow"
+CivilianBehavior.CIVILIAN_FIGHTER_CID = CIVILIAN_FIGHTER_CID
+CivilianBehavior.CIVILIAN_COWARD_CID = CIVILIAN_COWARD_CID
 
 local originalAreEnemies
 local originalNeedResupply
@@ -320,8 +325,18 @@ local function shouldForceFighter(zombie, brain, percents)
         return false
     end
 
-    if brain.cid and brain.cid ~= "" and brain.cid ~= CIVILIAN_CID then
-        return true
+    if brain.cid and brain.cid ~= "" then
+        if brain.cid == CIVILIAN_FIGHTER_CID then
+            return true
+        end
+
+        if brain.cid == CIVILIAN_COWARD_CID then
+            return false
+        end
+
+        if not CivilianGroups.IsCivilianCID(brain.cid) then
+            return true
+        end
     end
 
     local fighterPercent
@@ -556,7 +571,11 @@ local function canProvideProtection(zombie, brain)
     if not brain then
         return false
     end
-    if brain.cid ~= CIVILIAN_CID then
+    if not CivilianGroups.IsCivilianCID(brain.cid) then
+        return true
+    end
+
+    if brain.cid == CIVILIAN_FIGHTER_CID then
         return true
     end
     local role = getBrainRole(brain)
@@ -570,7 +589,7 @@ local function canProvideProtection(zombie, brain)
 end
 
 local function isCivilianBrain(brain)
-    return brain and brain.cid == CIVILIAN_CID
+    return brain and CivilianGroups.IsCivilianCID(brain.cid)
 end
 CivilianBehavior.isCivilianBrain = isCivilianBrain
 
@@ -1071,10 +1090,11 @@ local function applyRole(zombie, brain, role)
 
     if role == CivilianBehavior.ROLE_FIGHTER then
         brain._BanditTweaksCivilianCoward = nil
+        brain.cid = CIVILIAN_FIGHTER_CID
         return true
     end
 
-    brain.cid = CIVILIAN_CID
+    brain.cid = CIVILIAN_COWARD_CID
 
     applyCivilianDisarm(zombie, brain)
     setFriendlyState(zombie, brain)
@@ -1100,6 +1120,17 @@ end
 
 local function rollCivilianRole(zombie, brain)
     local fighter, hider, panic, shadow, percents = getRolePercents()
+
+    if brain and brain.cid == CIVILIAN_FIGHTER_CID then
+        return CivilianBehavior.ROLE_FIGHTER
+    end
+
+    if brain and brain.cid == CIVILIAN_COWARD_CID then
+        fighter = 0
+        if percents then
+            percents.fighter = 0
+        end
+    end
 
     if shouldForceFighter(zombie, brain, percents) then
         return CivilianBehavior.ROLE_FIGHTER
@@ -1130,6 +1161,7 @@ local function ensureRoleActive(zombie, brain, role)
         if brain then
             brain._BanditTweaksCivilianRole = role
             brain._BanditTweaksCivilianCoward = nil
+            brain.cid = CIVILIAN_FIGHTER_CID
         end
         return
     end
@@ -1252,7 +1284,7 @@ local function updateCivilianBehavior(zombie, brain)
 
     local modData = zombie:getModData()
 
-    if brain.cid ~= CIVILIAN_CID and not modData[CivilianBehavior.CIVILIAN_ROLE_KEY] then
+    if not CivilianGroups.IsCivilianCID(brain.cid) and not modData[CivilianBehavior.CIVILIAN_ROLE_KEY] then
         voiceTracker[zombie] = nil
         return
     end
@@ -1320,7 +1352,7 @@ function CivilianBehavior.convertFollowerToCivilian(zombie, brain)
         return false
     end
 
-    brain.cid = CIVILIAN_CID
+    brain.cid = CIVILIAN_COWARD_CID
     brain._BanditTweaksCivilianRole = nil
 
     local modData = zombie:getModData()

--- a/BanditTweaks/42/media/lua/shared/BanditTweaks/CivilianGroups.lua
+++ b/BanditTweaks/42/media/lua/shared/BanditTweaks/CivilianGroups.lua
@@ -1,0 +1,15 @@
+local CivilianGroups = {}
+
+CivilianGroups.FIGHTER_CID = "c167d1e0-c077-4ee5-b353-88b374de193d"
+CivilianGroups.COWARD_CID = "c3b0a7ac-6ae0-45cc-bf7b-0492ca0d21e3"
+
+CivilianGroups._cidLookup = {
+    [CivilianGroups.FIGHTER_CID] = true,
+    [CivilianGroups.COWARD_CID] = true,
+}
+
+function CivilianGroups.IsCivilianCID(cid)
+    return cid ~= nil and CivilianGroups._cidLookup[cid] == true
+end
+
+return CivilianGroups

--- a/BanditTweaks/42/media/lua/shared/BanditTweaks/Config.lua
+++ b/BanditTweaks/42/media/lua/shared/BanditTweaks/Config.lua
@@ -15,6 +15,8 @@ BanditTweaks.Defaults.civilianSeekProtectionPercent = 0
 BanditTweaks.Defaults.civilianVoicesEnabled = true
 BanditTweaks.Defaults.civilianRandomVoiceIntervalHours = 0.12
 BanditTweaks.Defaults.civilianHurtVoiceCooldownHours = 0.05
+BanditTweaks.Defaults.civilianFighterSpawnChance = 0.5
+BanditTweaks.Defaults.civilianCowardSpawnChance = 1.5
 BanditTweaks.Defaults.doorDisciplineEnabled = true
 BanditTweaks.Defaults.doorCloseCooldownHours = 0.02
 BanditTweaks.Defaults.startingFollowersEnabled = true
@@ -30,6 +32,8 @@ BanditTweaks.Config.civilianSeekProtectionPercent = BanditTweaks.Config.civilian
 BanditTweaks.Config.civilianVoicesEnabled = BanditTweaks.Config.civilianVoicesEnabled ~= false
 BanditTweaks.Config.civilianRandomVoiceIntervalHours = BanditTweaks.Config.civilianRandomVoiceIntervalHours or BanditTweaks.Defaults.civilianRandomVoiceIntervalHours
 BanditTweaks.Config.civilianHurtVoiceCooldownHours = BanditTweaks.Config.civilianHurtVoiceCooldownHours or BanditTweaks.Defaults.civilianHurtVoiceCooldownHours
+BanditTweaks.Config.civilianFighterSpawnChance = BanditTweaks.Config.civilianFighterSpawnChance or BanditTweaks.Defaults.civilianFighterSpawnChance
+BanditTweaks.Config.civilianCowardSpawnChance = BanditTweaks.Config.civilianCowardSpawnChance or BanditTweaks.Defaults.civilianCowardSpawnChance
 BanditTweaks.Config.doorDisciplineEnabled = BanditTweaks.Config.doorDisciplineEnabled ~= false
 BanditTweaks.Config.doorCloseCooldownHours = BanditTweaks.Config.doorCloseCooldownHours or BanditTweaks.Defaults.doorCloseCooldownHours
 BanditTweaks.Config.startingFollowersEnabled = BanditTweaks.Config.startingFollowersEnabled ~= false
@@ -59,6 +63,8 @@ function BanditTweaks.UpdateConfigFromSandbox()
     BanditTweaks.Config.civilianHidePercent = getSandboxNumber(options, "CivilianHidePercent", BanditTweaks.Defaults.civilianHidePercent)
     BanditTweaks.Config.civilianPanicPercent = getSandboxNumber(options, "CivilianPanicPercent", BanditTweaks.Defaults.civilianPanicPercent)
     BanditTweaks.Config.civilianSeekProtectionPercent = getSandboxNumber(options, "CivilianSeekProtectionPercent", BanditTweaks.Defaults.civilianSeekProtectionPercent)
+    BanditTweaks.Config.civilianFighterSpawnChance = getSandboxNumber(options, "CivilianFighterSpawnChance", BanditTweaks.Defaults.civilianFighterSpawnChance)
+    BanditTweaks.Config.civilianCowardSpawnChance = getSandboxNumber(options, "CivilianCowardSpawnChance", BanditTweaks.Defaults.civilianCowardSpawnChance)
     BanditTweaks.Config.civilianVoicesEnabled = getSandboxBoolean(options, "CivilianVoicesEnabled", BanditTweaks.Defaults.civilianVoicesEnabled)
     local voiceIntervalMinutes = getSandboxNumber(options, "CivilianVoiceIntervalMinutes", BanditTweaks.Defaults.civilianRandomVoiceIntervalHours * 60)
     local hurtCooldownMinutes = getSandboxNumber(options, "CivilianHurtVoiceCooldownMinutes", BanditTweaks.Defaults.civilianHurtVoiceCooldownHours * 60)

--- a/BanditTweaks/42/media/lua/shared/BanditTweaks/SpawnTweaks.lua
+++ b/BanditTweaks/42/media/lua/shared/BanditTweaks/SpawnTweaks.lua
@@ -1,6 +1,118 @@
 require "BanditTweaks/Config"
+local CivilianGroups = require "BanditTweaks/CivilianGroups"
 
 local SpawnTweaks = {}
+
+local function deepCopy(value)
+    if type(value) ~= "table" then
+        return value
+    end
+
+    local copy = {}
+    for key, entry in pairs(value) do
+        copy[key] = deepCopy(entry)
+    end
+    return copy
+end
+
+function BanditTweaks.RewriteCivilianClans()
+    if not BanditCustom or not BanditCustom.clanData or not BanditCustom.banditData then
+        return
+    end
+
+    local fighterCid = CivilianGroups.FIGHTER_CID
+    local cowardCid = CivilianGroups.COWARD_CID
+
+    local fighterClan = BanditCustom.clanData[fighterCid]
+    if not fighterClan then
+        return
+    end
+
+    fighterClan.general = fighterClan.general or {}
+    fighterClan.spawn = fighterClan.spawn or {}
+
+    local baseName = fighterClan.general.name
+    if not baseName or baseName == "" then
+        baseName = "Civilians"
+    end
+
+    if baseName == "Civilians" then
+        fighterClan.general.name = "Civilian Fighters"
+    end
+
+    local cowardClan = BanditCustom.clanData[cowardCid]
+    if not cowardClan then
+        cowardClan = deepCopy(fighterClan)
+        BanditCustom.clanData[cowardCid] = cowardClan
+    end
+
+    cowardClan.general = cowardClan.general or {}
+    cowardClan.spawn = cowardClan.spawn or {}
+
+    local fighterName = fighterClan.general.name or baseName
+    if not cowardClan.general.name or cowardClan.general.name == "" or cowardClan.general.name == baseName or cowardClan.general.name == fighterName then
+        if fighterName:find("Fighter") then
+            cowardClan.general.name = fighterName:gsub("Fighter", "Coward")
+        else
+            cowardClan.general.name = fighterName .. " Cowards"
+        end
+    end
+
+    for key, value in pairs(fighterClan.spawn) do
+        if key ~= "spawnChance" then
+            cowardClan.spawn[key] = value
+        end
+    end
+
+    local toRemove = {}
+    for bid, data in pairs(BanditCustom.banditData) do
+        local general = data and data.general
+        if general and general._BanditTweaksCowardClone then
+            table.insert(toRemove, bid)
+        end
+    end
+
+    for _, bid in ipairs(toRemove) do
+        BanditCustom.banditData[bid] = nil
+    end
+
+    local originals = {}
+    for bid, data in pairs(BanditCustom.banditData) do
+        local general = data and data.general
+        if general and general.cid == fighterCid and not general._BanditTweaksCowardClone then
+            table.insert(originals, {id = bid, data = data})
+        end
+    end
+
+    for _, entry in ipairs(originals) do
+        local clone = deepCopy(entry.data)
+        clone.general = clone.general or {}
+        clone.general.cid = cowardCid
+        clone.general._BanditTweaksCowardClone = true
+        clone.general._BanditTweaksSourceId = entry.id
+
+        if clone.general.name and clone.general.name ~= "" then
+            if not clone.general.name:find("Coward") then
+                clone.general.name = clone.general.name .. " Coward"
+            end
+        else
+            clone.general.name = "Civilian Coward"
+        end
+
+        local newId
+        if BanditCustom.GetNextId then
+            newId = BanditCustom.GetNextId(entry.id)
+        elseif getRandomUUID then
+            newId = getRandomUUID()
+        end
+
+        if not newId then
+            newId = tostring(entry.id) .. "_coward"
+        end
+
+        BanditCustom.banditData[newId] = clone
+    end
+end
 
 function BanditTweaks.AdjustBanditSpawnDistance(dist)
     if type(dist) == "number" then
@@ -14,13 +126,29 @@ function BanditTweaks.AdjustClanSpawnChances()
         return
     end
 
-    for _, clan in pairs(BanditCustom.clanData) do
+    local fighterCid = CivilianGroups.FIGHTER_CID
+    local cowardCid = CivilianGroups.COWARD_CID
+    local defaults = BanditTweaks.Defaults or {}
+
+    for cid, clan in pairs(BanditCustom.clanData) do
         local spawn = clan and clan.spawn
-        if spawn and spawn.friendly == false and not spawn._BanditTweaksAdjusted then
-            if type(spawn.spawnChance) == "number" then
-                spawn.spawnChance = spawn.spawnChance * BanditTweaks.Config.hostileSpawnChanceMultiplier
+        if spawn then
+            if cid == fighterCid then
+                local chance = BanditTweaks.Config.civilianFighterSpawnChance or defaults.civilianFighterSpawnChance or 0
+                spawn.spawnChance = chance
+                spawn.friendly = true
+                spawn._BanditTweaksAdjusted = true
+            elseif cid == cowardCid then
+                local chance = BanditTweaks.Config.civilianCowardSpawnChance or defaults.civilianCowardSpawnChance or 0
+                spawn.spawnChance = chance
+                spawn.friendly = true
+                spawn._BanditTweaksAdjusted = true
+            elseif spawn.friendly == false and not spawn._BanditTweaksAdjusted then
+                if type(spawn.spawnChance) == "number" then
+                    spawn.spawnChance = spawn.spawnChance * BanditTweaks.Config.hostileSpawnChanceMultiplier
+                end
+                spawn._BanditTweaksAdjusted = true
             end
-            spawn._BanditTweaksAdjusted = true
         end
     end
 end
@@ -35,10 +163,12 @@ local function tryPatchBanditCustom()
         local originalLoad = BanditCustom.Load
         BanditCustom.Load = function(...)
             local result = originalLoad(...)
+            BanditTweaks.RewriteCivilianClans()
             BanditTweaks.AdjustClanSpawnChances()
             return result
         end
         BanditTweaks._patchedBanditCustom = true
+        BanditTweaks.RewriteCivilianClans()
         BanditTweaks.AdjustClanSpawnChances()
         Events.OnTick.Remove(tryPatchBanditCustom)
     end

--- a/BanditTweaks/42/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/BanditTweaks/42/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -23,6 +23,12 @@ Sandbox_EN = {
     Sandbox_BanditTweaks.CivilianSeekProtectionPercent = "Protection seeker percentage",
     Sandbox_BanditTweaks.CivilianSeekProtectionPercent_tooltip = "Portion of non-combat civilians that will shadow nearby allies who can fight to stay safe.",
 
+    Sandbox_BanditTweaks.CivilianFighterSpawnChance = "Civilian fighter spawn chance",
+    Sandbox_BanditTweaks.CivilianFighterSpawnChance_tooltip = "Chance that a civilian squad made up of fighters will spawn when the game schedules friendly bandit events.",
+
+    Sandbox_BanditTweaks.CivilianCowardSpawnChance = "Civilian coward spawn chance",
+    Sandbox_BanditTweaks.CivilianCowardSpawnChance_tooltip = "Chance that a coward-focused civilian group will spawn when the game schedules friendly bandit events.",
+
     Sandbox_BanditTweaks.CivilianVoicesEnabled = "Civilian voice reactions enabled",
     Sandbox_BanditTweaks.CivilianVoicesEnabled_tooltip = "Toggles whether civilians shout fearful voice lines when stressed or injured.",
 

--- a/BanditTweaks/42/media/sandbox-options.txt
+++ b/BanditTweaks/42/media/sandbox-options.txt
@@ -35,6 +35,16 @@ option BanditTweaks.CivilianSeekProtectionPercent = {
     page = BanditTweaks, translation = BanditTweaks.CivilianSeekProtectionPercent, _tooltip = BanditTweaks.CivilianSeekProtectionPercent_tooltip,
 }
 
+option BanditTweaks.CivilianFighterSpawnChance = {
+    type = double, min = 0, max = 20, default = 0.5,
+    page = BanditTweaks, translation = BanditTweaks.CivilianFighterSpawnChance, _tooltip = BanditTweaks.CivilianFighterSpawnChance_tooltip,
+}
+
+option BanditTweaks.CivilianCowardSpawnChance = {
+    type = double, min = 0, max = 20, default = 1.5,
+    page = BanditTweaks, translation = BanditTweaks.CivilianCowardSpawnChance, _tooltip = BanditTweaks.CivilianCowardSpawnChance_tooltip,
+}
+
 option BanditTweaks.CivilianVoicesEnabled = {
     type = boolean, default = true,
     page = BanditTweaks, translation = BanditTweaks.CivilianVoicesEnabled, _tooltip = BanditTweaks.CivilianVoicesEnabled_tooltip,


### PR DESCRIPTION
## Summary
- add a shared civilian group registry and use it throughout CivilianBehavior so fighter and coward clans get distinct roles and metadata
- rewrite the Bandit custom data at load time to duplicate civilian bandits into a coward clan and apply the configured fighter/coward spawn chances
- surface sandbox defaults and translations for fighter and coward civilian spawn chances

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d414c6ecc483329e62f91d0a4d8121